### PR TITLE
Only draw text on the side facing you!

### DIFF
--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -72,11 +72,7 @@ local plyShootPos, ang, pos, camangle, showFront -- Less variables being created
 hook.Add( "PostDrawTranslucentRenderables", "SammyServers3D2DTextScreens", function()
 
 	-- Cache the shoot pos for this frame
-	if IsValid(LocalPlayer()) then
-		plyShootPos = LocalPlayer():GetShootPos()
-	else
-		return
-	end
+	plyShootPos = LocalPlayer():GetShootPos()
 
 	for k, self in ipairs(toDraw) do
 		if IsValid(self) and screenInfo[self] != nil then
@@ -98,10 +94,8 @@ hook.Add( "PostDrawTranslucentRenderables", "SammyServers3D2DTextScreens", funct
 
 					render.PopFilterMin()
 				cam.End3D2D()
-			end
-
+			else
 			-- Draw the back of the screen
-			if not showFront then
 				camangle:RotateAroundAxis(camangle:Right(), 180)
 				cam.Start3D2D(pos, camangle, .25)
 					render.PushFilterMin(TEXFILTER.ANISOTROPIC)

--- a/lua/textscreens_config.lua
+++ b/lua/textscreens_config.lua
@@ -16,129 +16,134 @@ Custom fonts - requires server restart to take affect -- "Screens_" will be remo
 ---------------------------------------------------------------------------*/
 
 // Default textscreens font
-addFont("Coolvetica outlined", {
-	font = "coolvetica",
-	weight = 400,
-	antialias = false,
-	outline = true
-})
+local function addFonts()
+	textscreenFonts = {}
 
-addFont("Coolvetica", {
-	font = "coolvetica",
-	weight = 400,
-	antialias = false,
-	outline = false
-})
+	addFont("Coolvetica outlined", {
+		font = "coolvetica",
+		weight = 400,
+		antialias = false,
+		outline = true
+	})
 
-// Trebuchet
-addFont("Screens_Trebuchet outlined", {
-	font = "Trebuchet18",
-	weight = 400,
-	antialias = false,
-	outline = true
-})
+	addFont("Coolvetica", {
+		font = "coolvetica",
+		weight = 400,
+		antialias = false,
+		outline = false
+	})
 
-addFont("Screens_Trebuchet", {
-	font = "Trebuchet18",
-	weight = 400,
-	antialias = false,
-	outline = false
-})
+	// Trebuchet
+	addFont("Screens_Trebuchet outlined", {
+		font = "Trebuchet18",
+		weight = 400,
+		antialias = false,
+		outline = true
+	})
 
-// Arial
-addFont("Screens_Arial outlined", {
-	font = "Arial",
-	weight = 600,
-	antialias = false,
-	outline = true
-})
+	addFont("Screens_Trebuchet", {
+		font = "Trebuchet18",
+		weight = 400,
+		antialias = false,
+		outline = false
+	})
 
-addFont("Screens_Arial", {
-	font = "Arial",
-	weight = 600,
-	antialias = false,
-	outline = false
-})
+	// Arial
+	addFont("Screens_Arial outlined", {
+		font = "Arial",
+		weight = 600,
+		antialias = false,
+		outline = true
+	})
 
-// Roboto Bk
-addFont("Screens_Roboto outlined", {
-	font = "Roboto Bk",
-	weight = 400,
-	antialias = false,
-	outline = true
-})
+	addFont("Screens_Arial", {
+		font = "Arial",
+		weight = 600,
+		antialias = false,
+		outline = false
+	})
 
-addFont("Screens_Roboto", {
-	font = "Roboto Bk",
-	weight = 400,
-	antialias = false,
-	outline = false
-})
+	// Roboto Bk
+	addFont("Screens_Roboto outlined", {
+		font = "Roboto Bk",
+		weight = 400,
+		antialias = false,
+		outline = true
+	})
 
-// Helvetica
-addFont("Screens_Helvetica outlined", {
-	font = "Helvetica",
-	weight = 400,
-	antialias = false,
-	outline = true
-})
+	addFont("Screens_Roboto", {
+		font = "Roboto Bk",
+		weight = 400,
+		antialias = false,
+		outline = false
+	})
 
-addFont("Screens_Helvetica", {
-	font = "Helvetica",
-	weight = 400,
-	antialias = false,
-	outline = false
-})
+	// Helvetica
+	addFont("Screens_Helvetica outlined", {
+		font = "Helvetica",
+		weight = 400,
+		antialias = false,
+		outline = true
+	})
 
-// akbar
-addFont("Screens_akbar outlined", {
-	font = "akbar",
-	weight = 400,
-	antialias = false,
-	outline = true
-})
+	addFont("Screens_Helvetica", {
+		font = "Helvetica",
+		weight = 400,
+		antialias = false,
+		outline = false
+	})
 
-addFont("Screens_akbar", {
-	font = "akbar",
-	weight = 400,
-	antialias = false,
-	outline = false
-})
+	// akbar
+	addFont("Screens_akbar outlined", {
+		font = "akbar",
+		weight = 400,
+		antialias = false,
+		outline = true
+	})
+
+	addFont("Screens_akbar", {
+		font = "akbar",
+		weight = 400,
+		antialias = false,
+		outline = false
+	})
 
 
-// boogaloo
-addFont("Screens_boogaloo outlined", {
-	font = "boogaloo",
-	weight = 400,
-	antialias = false,
-	outline = true
-})
+	// boogaloo
+	addFont("Screens_boogaloo outlined", {
+		font = "boogaloo",
+		weight = 400,
+		antialias = false,
+		outline = true
+	})
 
-addFont("Screens_boogaloo", {
-	font = "boogaloo",
-	weight = 400,
-	antialias = false,
-	outline = false
-})
+	addFont("Screens_boogaloo", {
+		font = "boogaloo",
+		weight = 400,
+		antialias = false,
+		outline = false
+	})
 
-// csd
-addFont("Screens_csd outlined", {
-	font = "csd",
-	weight = 400,
-	antialias = false,
-	outline = true
-})
+	// csd
+	addFont("Screens_csd outlined", {
+		font = "csd",
+		weight = 400,
+		antialias = false,
+		outline = true
+	})
 
-addFont("Screens_csd", {
-	font = "csd",
-	weight = 400,
-	antialias = false,
-	outline = false
-})
+	addFont("Screens_csd", {
+		font = "csd",
+		weight = 400,
+		antialias = false,
+		outline = false
+	})
+end
+addFonts()
 
 if CLIENT then
 
-	local function addFonts(path)
+	local function showFonts(path)
 		local files, folders = file.Find("resource/fonts/" .. path .. "*", "MOD")
 
 		for k, v in ipairs(files) do
@@ -157,12 +162,15 @@ addFont("Screens_ ]] .. font .. [[", {
 		end
 
 		for k, v in ipairs(folders) do
-			addFonts(path .. v .. "/")
+			showFonts(path .. v .. "/")
 		end
 	end
 
 	concommand.Add("get_fonts", function(ply)
-		addFonts("")
+		showFonts("")
 	end)
 
+	// Font fix from darkrp
+	hook.Add("InitPostEntity", "3D2DTextScreens_LoadFonts", addFonts)
+	
 end


### PR DESCRIPTION
This is a small edit which stops the text screen entity from drawing on both sides. With this, only the side facing you will be drawn.

`draw.DrawText` Was one of the most expensive calls on my client according to FProfiler, this halves the call count at the expense of a little maths.