### PR TITLE
 Replaced draw.DrawText with surface.DrawText

### DIFF
--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -8,7 +8,7 @@ local textscreenFonts = textscreenFonts
 local screenInfo = {}
 local toDraw = {}
 
--- ENUM type things faster faster table indexing
+-- ENUM type things for faster table indexing
 local FONT = 1
 local TEXT = 2
 local POSX = 3

--- a/lua/entities/sammyservers_textscreen/shared.lua
+++ b/lua/entities/sammyservers_textscreen/shared.lua
@@ -4,6 +4,7 @@ ENT.PrintName = "SammyServers Textscreen"
 ENT.Author = "SammyServers"
 ENT.Spawnable = false
 ENT.AdminSpawnable = false
+ENT.RenderGroup = RENDERGROUP_TRANSLUCENT
 
 function ENT:SetupDataTables()
 	self:NetworkVar("Bool", 0, "IsPersisted")

--- a/lua/entities/sammyservers_textscreen/shared.lua
+++ b/lua/entities/sammyservers_textscreen/shared.lua
@@ -4,7 +4,7 @@ ENT.PrintName = "SammyServers Textscreen"
 ENT.Author = "SammyServers"
 ENT.Spawnable = false
 ENT.AdminSpawnable = false
-ENT.RenderGroup = RENDERGROUP_TRANSLUCENT
+ENT.RenderGroup = RENDERGROUP_BOTH
 
 function ENT:SetupDataTables()
 	self:NetworkVar("Bool", 0, "IsPersisted")


### PR DESCRIPTION
I looked up the source for draw.DrawText and found that it ends up calling surface.DrawText. This update bypasses the extra function calls. I have also changed the table indexing for getting information about text, position, colour and other things to a number/enum system for the rendering hook so that table lookups should be faster.

My quick performance test setup:
- A single text screen with five lines, size 100
- Font Roboto outlined
- "This is a test text screen." on each line
- Random colour for each line
- Standing 205 units away, directly facing the screen

The latest text screens off of github:
- Called 772 times
- Profiling time in seconds, 10.29
- Total time in ms, 36.489
- Average time in ms, 0.047

This pull request:
- Called 812 times
- Profiling time in seconds, 10.26
- Total time in ms, 22.62
- Average time in ms, 0.028