### PR TITLE
Fix draw order by changing ENT:Draw to ENT:DrawTranslucent

### DIFF
--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -75,7 +75,7 @@ local function Draw3D2D(ang, pos, camangle, data)
 end
 
 local plyShootPos, ang, pos, camangle, showFront, data -- Less variables being created each frame
-function ENT:Draw()
+function ENT:DrawTranslucent()
 	-- Cache the shoot pos for this frame
 	plyShootPos = LocalPlayer():GetShootPos()
 

--- a/lua/entities/sammyservers_textscreen/shared.lua
+++ b/lua/entities/sammyservers_textscreen/shared.lua
@@ -1,10 +1,10 @@
 ENT.Type = "anim"
-ENT.Base = "base_gmodentity"
+ENT.Base = "base_entity"
 ENT.PrintName = "SammyServers Textscreen"
 ENT.Author = "SammyServers"
 ENT.Spawnable = false
 ENT.AdminSpawnable = false
-ENT.RenderGroup = RENDERGROUP_BOTH
+ENT.RenderGroup = RENDERGROUP_TRANSLUCENT
 
 function ENT:SetupDataTables()
 	self:NetworkVar("Bool", 0, "IsPersisted")


### PR DESCRIPTION
Changed base_gmodentity to base_entity to reduce the size of the meta table inheritance as it doesn't seem like it's needed.

For some reason, ENT:Draw doesn't get called late enough so stuff gets drawn in front of it. However, ENT:DrawTranslucent does get called late enough so that materials from windows/props with a custom material no longer get drawn in front of the text.

I've changed RENDERGROUP_BOTH to RENDERGROUP_TRANSLUCENT as the wiki says RENDERGROUP_BOTH calls ENT:Draw and ENT:DrawTranslucent whereas RENDERGROUP_TRANSLUCENT only calls ENT:DrawTranslucent.

Sorry about my typo with the colours in my last commit.