### PR TITLE
Remove Travis, switch permanently to GitHub Actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: minimal
-
-install:
-  - curl -o glualint.zip -L https://github.com/FPtje/GLuaFixer/releases/download/1.11.2/glualint-1.11.2-linux.zip
-  - unzip glualint.zip
-
-script:
-  - ./glualint lua

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [<img src="https://up.jross.me/textscreens/nodecraft-logo-light.svg" alt="Powered by Nodecraft" width="300px">](https://nodecraft.com/r/textscreens)
 
-[![Actions Status](https://github.com/Cherry/3D2D-Textscreens/workflows/Test/badge.svg)](https://github.com/Cherry/3D2D-Textscreens/actions)
+[![Actions Status](https://github.com/Cherry/3D2D-Textscreens/workflows/Lint/badge.svg)](https://github.com/Cherry/3D2D-Textscreens/actions)
 [![Steam Workshop Subscribers](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fshieldsio-steam-workshop.jross.me%2F109643223&style=for-the-badge)](https://steamcommunity.com/sharedfiles/filedetails/?id=109643223)
 > This addon can be installed via the [Steam Workshop for Garry's Mod](https://steamcommunity.com/sharedfiles/filedetails/?id=109643223) - I do not recommend manually installing this addon via git.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [<img src="https://up.jross.me/textscreens/nodecraft-logo-light.svg" alt="Powered by Nodecraft" width="300px">](https://nodecraft.com/r/textscreens)
 
-[![Build Status](https://img.shields.io/travis/Cherry/3D2D-Textscreens/master.svg?style=for-the-badge)](https://travis-ci.org/Cherry/3D2D-Textscreens)
+[![Actions Status](https://github.com/Cherry/3D2D-Textscreens/workflows/Test/badge.svg)](https://github.com/Cherry/3D2D-Textscreens/actions)
 [![Steam Workshop Subscribers](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fshieldsio-steam-workshop.jross.me%2F109643223&style=for-the-badge)](https://steamcommunity.com/sharedfiles/filedetails/?id=109643223)
 > This addon can be installed via the [Steam Workshop for Garry's Mod](https://steamcommunity.com/sharedfiles/filedetails/?id=109643223) - I do not recommend manually installing this addon via git.
 

--- a/addon.json
+++ b/addon.json
@@ -6,9 +6,9 @@
 		"roleplay"
 	],
 	"ignore": [
+		".github",
 		".gitignore",
 		".glualint.json",
-		".travis.yml",
 		"LICENSE",
 		"*.exe",
 		"*.md"


### PR DESCRIPTION
No need for Travis anymore - GitHub Actions does everything we need. 🎉