### PR TITLE
Added textscreen entity to pocket blacklist for DarkRP

### DIFF
--- a/lua/autorun/textscreens_util.lua
+++ b/lua/autorun/textscreens_util.lua
@@ -163,6 +163,12 @@ if SERVER then
 			return printMessage(ply, "Textscreen removed and is no longer permanent.")
 		end
 	end)
+
+	-- Add to pocket blacklist for DarkRP
+	-- Not using gamemode == "darkrp" because there are lots of flavours of darkrp
+	hook.Add("loadCustomDarkRPItems", "sammyservers_pocket_blacklist", function()
+		GAMEMODE.Config.PocketBlacklist["sammyservers_textscreen"] = true
+	end)
 end
 
 if CLIENT then


### PR DESCRIPTION
This has been something which lots of server owners have had problems with. When people pocket text screens. It's something every server has to add eventually to their pocket blacklist so why not include it by default?

I was prompted to do this after hopping onto the Steam forums and this was the first thing I saw.
https://steamcommunity.com/app/4000/discussions/5/2934616148065045201/

I've tested this in single-player DarkRP and it worked. Because it's adding the blacklist from within a hook, it will only be called and set within a DarkRP derived gamemode.
