### PR TITLE
Fix textscreens.txt is empty test

### DIFF
--- a/lua/autorun/textscreens_util.lua
+++ b/lua/autorun/textscreens_util.lua
@@ -76,7 +76,7 @@ if SERVER then
 	local function SpawnPermaTextscreens()
 		print("[3D2D Textscreens] Spawning textscreens...")
 		textscreens = file.Read("sammyservers_textscreens.txt", "DATA")
-		if not textscreens or textscreens == "" then
+		if not textscreens or textscreens == "[]" then
 			textscreens = {}
 			print("[3D2D Textscreens] Spawned 0 textscreens for map " .. game.GetMap())
 			return


### PR DESCRIPTION
When a perma textscreen is added then removed the txt reverts to "[]", not ""
You can alternatively fix this issue by fixing how the file is written when perma textscreens are removed.

Don't have the time to confirm but what I can say is removing "sammyservers_textscreens.txt" from the servers dir seems to have fixed the perma-perma textscreens bug, presumably because this test is passing for once.

For more information: After removing a perma-perma textscreen from the map I read the .txt to see "[]", if this is consistent behavior that would imply the test on 79 can only pass if not textscreens
I tried to force that test to pass by deleting the text file, and on our next restart the perma-perma textscreen was gone. If everything I said is accurate and deleting the txt did directly fix the bug, then I'm aware this is a band-aid fix but this has been an issue for nearly 6 years, and it looks to me that the test is faulty anyway.

Thanks for reading.