### PR TITLE
Throttle download net message

### DIFF
--- a/lua/entities/sammyservers_textscreen/init.lua
+++ b/lua/entities/sammyservers_textscreen/init.lua
@@ -111,7 +111,7 @@ net.Receive("textscreens_download", function(len, ply)
 end)
 
 function ENT:SendLines(ply)
-	self.lines = self.lines or {}
+	if not self.lines then self.lines = {} end
 
 	net.Start("textscreens_update")
 	net.WriteEntity(self)

--- a/lua/entities/sammyservers_textscreen/init.lua
+++ b/lua/entities/sammyservers_textscreen/init.lua
@@ -90,7 +90,7 @@ do
 		now = CurTime()
 		lastSent = updates[ent] or 0
 		if lastSent > ( now - 1 ) then
-		    return false
+			return false
 		end
 
 		updates[ent] = now
@@ -107,16 +107,23 @@ net.Receive("textscreens_download", function(len, ply)
 
 	if not canSendUpdate(ply, ent) then return end
 
-	ent.lines = ent.lines or {}
-	net.Start("textscreens_update")
-		net.WriteEntity(ent)
-		net.WriteTable(ent.lines)
-	net.Send(ply)
+	ent:SendLines(ply)
 end)
 
-function ENT:Broadcast()
+function ENT:SendLines(ply)
+	self.lines = self.lines or {}
+
 	net.Start("textscreens_update")
-		net.WriteEntity(self)
-		net.WriteTable(self.lines)
-	net.Broadcast()
+	net.WriteEntity(self)
+	net.WriteTable(self.lines)
+
+	if ply then
+		net.Send(ply)
+	else
+		net.Broadcast()
+	end
+end
+
+function ENT:Broadcast()
+	self:SendLines(nil)
 end

--- a/lua/entities/sammyservers_textscreen/init.lua
+++ b/lua/entities/sammyservers_textscreen/init.lua
@@ -76,25 +76,30 @@ function ENT:SetLine(line, text, color, size, font, rainbow)
 	}
 end
 
-local canSendUpdate
+local function canSendUpdate(ply, ent)
+	local updates = ply.TextScreenUpdates
+	if not updates then
+		updates = {}
+		ply.TextScreenUpdates = updates
+	end
 
-do
-	local updates, now, lastSent
-	canSendUpdate = function(ply, ent)
-		updates = ply.TextScreenUpdates
-		if not updates then
-			updates = {}
-			ply.TextScreenUpdates = updates
-		end
+	local now = CurTime()
+	local lastSent = updates[ent] or 0
+	if lastSent > (now - 1) then
+		return false
+	end
 
-		now = CurTime()
-		lastSent = updates[ent] or 0
-		if lastSent > ( now - 1 ) then
-			return false
-		end
+	updates[ent] = now
+	return true
+end
 
-		updates[ent] = now
-		return true
+function ENT:OnRemove()
+	local plys = player.GetAll()
+	local plyCount = #plys
+
+	for i = 1, plyCount do
+		local updates = plys[i].TextScreenUpdates
+		if updates then updates[self] = nil end
 	end
 end
 


### PR DESCRIPTION
This should address a relatively minor issue that would allow malicious players to spam-download a text screen's current state.

It simply throttles the download net message to once per second.

Because the throttles are stored on the player, the memory for the throttles should be self-managed as players leave.

**I also reworked the net update itself**:
Moving the networking into a function on the entity will let other addons control if/when screen updates occur.