### PR TITLE
Optimise rainbow text

### DIFF
--- a/lua/autorun/textscreens_util.lua
+++ b/lua/autorun/textscreens_util.lua
@@ -24,8 +24,6 @@ if SERVER then
 	CreateConVar("sbox_maxtextscreens", "1", {FCVAR_NOTIFY, FCVAR_REPLICATED}, "Determines the maximum number of textscreens users can spawn.")
 	CreateConVar("ss_call_to_home", 0, {FCVAR_NOTIFY, FCVAR_REPLICATED}, "Determines whether anonymous usage analytics can be sent to the addon author.", 0, 1)
 
-	--local rainbow_enabled = cvars.Number('ss_enable_rainbow', 1)
-
 	local version = "1.20.0"
 
 	local function GetOS()

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -182,7 +182,7 @@ local function AddDrawingInfo(ent, rawData)
 		-- Colour
 		if rawData[i].rainbow ~= 0 then
 			-- Render as solid white if ss_render_rainbow is disabled or server disabled via ss_enable_rainbow
-			drawData[i][COL] = surface.SetTextColor(255, 255, 255)
+			drawData[i][COL] = Color(255, 255, 255)
 		else
 			drawData[i][COL] = Color(rawData[i].color.r, rawData[i].color.g, rawData[i].color.b, 255)
 		end

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -22,7 +22,6 @@ local COL = 5
 local SIZE = 7
 local CAMSIZE = 8
 local RAINBOW = 9
-local UTF8CODES = 10
 
 -- Make ply:ShouldDrawLocalPlayer() never get called more than once a frame
 hook.Add("Think", "ss_should_draw_both_sides", function()
@@ -96,11 +95,11 @@ local function Draw3D2D(ang, pos, camangle, data)
 			surface.SetTextPos(row[POSX], row[POSY])
 			-- Rainbow
 			if row[RAINBOW] ~= 0 and rainbow_enabled and render_rainbow then
-				for i, char in pairs(row[UTF8CODES]) do
+				for i=1, #row[TEXT] do
 					--Color
 					surface.SetTextColor(toNearestColour((multipliedCurtime - i * speed) % 360))
 					--Text
-					surface.DrawText(char)
+					surface.DrawText(row[TEXT][i])
 				end
 			else
 				--Color
@@ -160,16 +159,6 @@ local function AddDrawingInfo(ent, rawData)
 		return #str == 0 or #string.Replace(str, " ", "") == 0
 	end
 
-	local function offsetAndUTF8(str)
-		local codes = {}
-		local offset = 0
-		for _, code in utf8.codes(str) do
-			offset = offset + 1
-			codes[offset] = utf8.char(code)
-		end
-		return codes
-	end
-
 	for i = 1, #rawData do
 		-- Setup tables
 		if not rawData[i] or isEmptyString(rawData[i].text) then continue end
@@ -177,10 +166,6 @@ local function AddDrawingInfo(ent, rawData)
 		textSize[i] = {}
 		-- Text
 		drawData[i][TEXT] = rawData[i].text
-		-- UTF8 rainbow
-		if rawData[i].rainbow ~= 0 then
-			drawData[i][UTF8CODES] = offsetAndUTF8(drawData[i][TEXT])
-		end
 		-- Font
 		drawData[i][FONT] = (ValidFont(rawData[i].font) or textscreenFonts[1])
 		-- Text size

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -169,53 +169,56 @@ local function AddDrawingInfo(ent, rawData)
 		return chars
 	end
 
-	for i = 1, #rawData do
+	for lineNum, line in pairs(rawData) do
 		-- Setup tables
-		if not rawData[i] or isEmptyString(rawData[i].text) then continue end
-		drawData[i] = {}
-		textSize[i] = {}
+		drawData[lineNum] = {}
+		textSize[lineNum] = {}
 		-- Text
-		drawData[i][TEXT] = rawData[i].text
+		drawData[lineNum][TEXT] = line.text
 		-- UTF8 rainbow
-		if rawData[i].rainbow ~= 0 then
-			drawData[i][UTF8CODES] = toUTF8Chars(drawData[i][TEXT])
+		if line.rainbow ~= 0 then
+			drawData[lineNum][UTF8CODES] = toUTF8Chars(line.text)
 		end
 		-- Font
-		drawData[i][FONT] = (ValidFont(rawData[i].font) or textscreenFonts[1])
+		drawData[lineNum][FONT] = (ValidFont(line.font) or textscreenFonts[1])
 		-- Text size
-		surface.SetFont(drawData[i][FONT])
-		textSize[i][1], textSize[i][2] = surface.GetTextSize(drawData[i][TEXT])
-		textSize[i][2] = rawData[i].size
+		surface.SetFont(drawData[lineNum][FONT])
+		textSize[lineNum][1], textSize[lineNum][2] = surface.GetTextSize(drawData[lineNum][TEXT])
+		textSize[lineNum][2] = line.size
 		-- Workout max width for render bounds
-		maxWidth = maxWidth > textSize[i][1] and maxWidth or textSize[i][1]
+		maxWidth = maxWidth > textSize[lineNum][1] and maxWidth or textSize[lineNum][1]
 		-- Position
-		totalHeight = totalHeight + textSize[i][2]
+		totalHeight = totalHeight + textSize[lineNum][2]
 		-- Colour
-		if rawData[i].rainbow ~= 0 then
+		if line.rainbow ~= 0 then
 			-- Render as solid white if ss_render_rainbow is disabled or server disabled via ss_enable_rainbow
-			drawData[i][COL] = Color(255, 255, 255)
+			drawData[lineNum][COL] = Color(255, 255, 255)
 		else
-			drawData[i][COL] = Color(rawData[i].color.r, rawData[i].color.g, rawData[i].color.b, 255)
+			drawData[lineNum][COL] = Color(
+				line.color.r, 
+				line.color.g, 
+				line.color.b, 
+				255
+			)
 		end
 		-- Size
-		drawData[i][SIZE] = rawData[i].size
+		drawData[lineNum][SIZE] = rawData[lineNum].size
 		--Rainbow
-		drawData[i][RAINBOW] = rawData[i].rainbow
+		drawData[lineNum][RAINBOW] = rawData[lineNum].rainbow
 	end
 
 	-- Sort out heights
-	for i = 1, #rawData do
-		if not rawData[i] or isEmptyString(rawData[i].text) then continue end
+	for lineNum, line in pairs(drawData) do
 		-- The x position at which to draw the text relative to the text screen entity
-		drawData[i][POSX] = math.ceil(-textSize[i][1] / 2)
+		drawData[lineNum][POSX] = math.ceil(-textSize[lineNum][1] / 2)
 		-- The y position at which to draw the text relative to the text screen entity
-		drawData[i][POSY] = math.ceil(-(totalHeight / 2) + currentHeight)
+		drawData[lineNum][POSY] = math.ceil(-(totalHeight / 2) + currentHeight)
 		-- Calculate the cam.Start3D2D size based on the size of the font
-		drawData[i][CAMSIZE] = (0.25 * drawData[i][SIZE]) / 100
+		drawData[lineNum][CAMSIZE] = (0.25 * drawData[lineNum][SIZE]) / 100
 		-- Use the CAMSIZE to "scale" the POSY
-		drawData[i][POSY] = (0.25 / drawData[i][CAMSIZE] * drawData[i][POSY])
+		drawData[lineNum][POSY] = (0.25 / drawData[lineNum][CAMSIZE] * drawData[lineNum][POSY])
 		-- Highest line to lowest, so that everything is central
-		currentHeight = currentHeight + textSize[i][2]
+		currentHeight = currentHeight + textSize[lineNum][2]
 	end
 
 	-- Add the new data to our text screen list

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -87,7 +87,7 @@ local function Draw3D2D(ang, pos, camangle, data)
 	local multipliedCurtime = CurTime() * 60
 	local speed = 5
 
-	for _, row in ipairs(data) do
+	for _, row in pairs(data) do
 		cam.Start3D2D(pos, camangle, row[CAMSIZE])
 			render.PushFilterMin(TEXFILTER.ANISOTROPIC)
 			-- Font

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -3,7 +3,7 @@ include("shared.lua")
 local render_convar_range = CreateClientConVar("ss_render_range", 1500, true, false, "Determines the render range for Textscreens. Default 1500")
 local render_rainbow = CreateClientConVar("ss_render_rainbow", 1, true, false, "Determines if rainbow screens are rendered. If disabled (0), will render as solid white. Default enabled (1)", 0, 1)
 local render_range = render_convar_range:GetInt() * render_convar_range:GetInt() --We multiply this is that we can use DistToSqr instead of Distance so we don't need to workout the square root all the time
-local rainbow_enabled = cvars.Number("ss_enable_rainbow", 1)
+local rainbow_enabled = cvars.Bool("ss_enable_rainbow", true)
 local textscreenFonts = textscreenFonts
 local screenInfo = {}
 local shouldDrawBoth = false
@@ -43,7 +43,7 @@ cvars.AddChangeCallback("ss_render_range", function(convar_name, value_old, valu
 end, "3D2DScreens")
 
 cvars.AddChangeCallback("ss_render_rainbow", function(convar_name, value_old, value_new)
-	render_rainbow = tonumber(value_new)
+	render_rainbow = tobool(value_new)
 end, "3D2DScreens")
 
 -- TODO: https://github.com/Facepunch/garrysmod-issues/issues/3740
@@ -73,7 +73,7 @@ end
 local function Draw3D2D(ang, pos, camangle, data)
 
 	for i = 1, data[LEN] do
-		cam.Start3D2D(pos, camangle, data[i][CAMSIZE] )
+		cam.Start3D2D(pos, camangle, data[i][CAMSIZE])
 			render.PushFilterMin(TEXFILTER.ANISOTROPIC)
 			-- Font
 			surface.SetFont(data[i][FONT])
@@ -85,7 +85,7 @@ local function Draw3D2D(ang, pos, camangle, data)
 				for _, code in utf8.codes(data[i][TEXT]) do
 					j = j + 1
 					--Color
-					if rainbow_enabled == 1 and render_rainbow ~= 0 then
+					if rainbow_enabled and render_rainbow then
 						surface.SetTextColor(HSVToColor((CurTime() * 60 + (j * 5)) % 360, 1, 1))
 					else
 						-- Render as solid white if ss_render_rainbow is disabled or server disabled via ss_enable_rainbow
@@ -149,7 +149,7 @@ local function AddDrawingInfo(ent, rawData)
 
 	for i = 1, #rawData do
 		-- Setup tables
-		if not rawData[i] or not rawData[i].text then continue end
+		if not rawData[i] or #rawData[i].text == 0 then continue end
 		drawData[i] = {}
 		textSize[i] = {}
 		-- Text
@@ -176,7 +176,7 @@ local function AddDrawingInfo(ent, rawData)
 
 	-- Sort out heights
 	for i = 1, #rawData do
-		if not rawData[i] or not rawData[i].text then continue end
+		if not rawData[i] or #rawData[i].text == 0 then continue end
 		-- The x position at which to draw the text relative to the text screen entity
 		drawData[i][POSX] = math.ceil(-textSize[i][1] / 2)
 		-- The y position at which to draw the text relative to the text screen entity

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -80,7 +80,7 @@ local function Draw3D2D(ang, pos, camangle, data)
 			-- Position
 			surface.SetTextPos(data[i][POSX], data[i][POSY])
 			-- Rainbow
-			if data[i][RAINBOW] ~= nil and data[i][RAINBOW] ~= 0 then
+			if data[i][RAINBOW] ~= 0 then
 				local j = 0
 				for _, code in utf8.codes(data[i][TEXT]) do
 					j = j + 1

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -73,8 +73,6 @@ end
 local function Draw3D2D(ang, pos, camangle, data)
 
 	for i = 1, data[LEN] do
-		if not data[i] or not data[i][TEXT] then continue end
-
 		cam.Start3D2D(pos, camangle, data[i][CAMSIZE] )
 			render.PushFilterMin(TEXFILTER.ANISOTROPIC)
 			-- Font
@@ -178,7 +176,7 @@ local function AddDrawingInfo(ent, rawData)
 
 	-- Sort out heights
 	for i = 1, #rawData do
-		if not rawData[i] then continue end
+		if not rawData[i] or not rawData[i].text then continue end
 		-- The x position at which to draw the text relative to the text screen entity
 		drawData[i][POSX] = math.ceil(-textSize[i][1] / 2)
 		-- The y position at which to draw the text relative to the text screen entity

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -191,9 +191,9 @@ local function AddDrawingInfo(ent, rawData)
 			drawData[lineNum][COL] = Color(255, 255, 255)
 		else
 			drawData[lineNum][COL] = Color(
-				line.color.r, 
-				line.color.g, 
-				line.color.b, 
+				line.color.r,
+				line.color.g,
+				line.color.b,
 				255
 			)
 		end

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -22,6 +22,7 @@ local COL = 5
 local SIZE = 7
 local CAMSIZE = 8
 local RAINBOW = 9
+local UTF8CODES = 10
 
 -- Make ply:ShouldDrawLocalPlayer() never get called more than once a frame
 hook.Add("Think", "ss_should_draw_both_sides", function()
@@ -86,7 +87,7 @@ local function Draw3D2D(ang, pos, camangle, data)
 	local multipliedCurtime = CurTime() * 60
 	local speed = 5
 
-	for _, row in pairs(data) do
+	for _, row in ipairs(data) do
 		cam.Start3D2D(pos, camangle, row[CAMSIZE])
 			render.PushFilterMin(TEXFILTER.ANISOTROPIC)
 			-- Font
@@ -95,11 +96,11 @@ local function Draw3D2D(ang, pos, camangle, data)
 			surface.SetTextPos(row[POSX], row[POSY])
 			-- Rainbow
 			if row[RAINBOW] ~= 0 and rainbow_enabled and render_rainbow then
-				for i = 1, #row[TEXT] do
+				for i, char in pairs(row[UTF8CODES]) do
 					--Color
 					surface.SetTextColor(toNearestColour((multipliedCurtime - i * speed) % 360))
 					--Text
-					surface.DrawText(row[TEXT][i])
+					surface.DrawText(char)
 				end
 			else
 				--Color
@@ -158,6 +159,16 @@ local function AddDrawingInfo(ent, rawData)
 		return #str == 0 or #string.Replace(str, " ", "") == 0
 	end
 
+	local function offsetAndUTF8(str)
+		local codes = {}
+		local offset = 0
+		for _, code in utf8.codes(str) do
+			offset = offset + 1
+			codes[offset] = utf8.char(code)
+		end
+		return codes
+	end
+
 	for i = 1, #rawData do
 		-- Setup tables
 		if not rawData[i] or isEmptyString(rawData[i].text) then continue end
@@ -165,6 +176,10 @@ local function AddDrawingInfo(ent, rawData)
 		textSize[i] = {}
 		-- Text
 		drawData[i][TEXT] = rawData[i].text
+		-- UTF8 rainbow
+		if rawData[i].rainbow ~= 0 then
+			drawData[i][UTF8CODES] = offsetAndUTF8(drawData[i][TEXT])
+		end
 		-- Font
 		drawData[i][FONT] = (ValidFont(rawData[i].font) or textscreenFonts[1])
 		-- Text size

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -161,14 +161,12 @@ local function AddDrawingInfo(ent, rawData)
 		return #str == 0 or #string.Replace(str, " ", "") == 0
 	end
 
-	local function offsetAndUTF8(str)
-		local codes = {}
-		local offset = 0
+	local function toUTF8Chars(str)
+		local chars = {}
 		for _, code in utf8.codes(str) do
-			offset = offset + 1
-			codes[offset] = utf8.char(code)
+			table.insert(chars, utf8.char(code))
 		end
-		return codes
+		return chars
 	end
 
 	for i = 1, #rawData do
@@ -180,7 +178,7 @@ local function AddDrawingInfo(ent, rawData)
 		drawData[i][TEXT] = rawData[i].text
 		-- UTF8 rainbow
 		if rawData[i].rainbow ~= 0 then
-			drawData[i][UTF8CODES] = offsetAndUTF8(drawData[i][TEXT])
+			drawData[i][UTF8CODES] = toUTF8Chars(drawData[i][TEXT])
 		end
 		-- Font
 		drawData[i][FONT] = (ValidFont(rawData[i].font) or textscreenFonts[1])

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -86,7 +86,7 @@ local function Draw3D2D(ang, pos, camangle, data)
 	local multipliedCurtime = CurTime() * 60
 	local speed = 5
 
-	for _, row in ipairs(data) do
+	for _, row in pairs(data) do
 		cam.Start3D2D(pos, camangle, row[CAMSIZE])
 			render.PushFilterMin(TEXFILTER.ANISOTROPIC)
 			-- Font

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -72,7 +72,7 @@ end
 local colours = {}
 local colourStep = 1 -- must be multiple of 360, lowering this seems to make no performance difference
 local mathFloor = math.floor -- cheaper than math.Round and close enough
-for i=0, 360-1, colourStep do -- 0 first index, 359 last index, length 360
+for i = 0, 360-1, colourStep do -- 0 first index, 359 last index, length 360
 	colours[i] = HSVToColor(i, 1, 1)
 end
 
@@ -86,7 +86,7 @@ local function Draw3D2D(ang, pos, camangle, data)
 	local multipliedCurtime = CurTime() * 60
 	local speed = 5
 
-	for i, row in ipairs(data) do
+	for _, row in ipairs(data) do
 		cam.Start3D2D(pos, camangle, row[CAMSIZE])
 			render.PushFilterMin(TEXFILTER.ANISOTROPIC)
 			-- Font
@@ -95,7 +95,7 @@ local function Draw3D2D(ang, pos, camangle, data)
 			surface.SetTextPos(row[POSX], row[POSY])
 			-- Rainbow
 			if row[RAINBOW] ~= 0 and rainbow_enabled and render_rainbow then
-				for i=1, #row[TEXT] do
+				for i = 1, #row[TEXT] do
 					--Color
 					surface.SetTextColor(toNearestColour((multipliedCurtime - i * speed) % 360))
 					--Text
@@ -153,7 +153,6 @@ local function AddDrawingInfo(ent, rawData)
 	local totalHeight = 0
 	local maxWidth = 0
 	local currentHeight = 0
-	local text = ""
 
 	local function isEmptyString(str)
 		return #str == 0 or #string.Replace(str, " ", "") == 0

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -157,10 +157,6 @@ local function AddDrawingInfo(ent, rawData)
 	local maxWidth = 0
 	local currentHeight = 0
 
-	local function isEmptyString(str)
-		return #str == 0 or #string.Replace(str, " ", "") == 0
-	end
-
 	local function toUTF8Chars(str)
 		local chars = {}
 		for _, code in utf8.codes(str) do

--- a/lua/entities/sammyservers_textscreen/cl_init.lua
+++ b/lua/entities/sammyservers_textscreen/cl_init.lua
@@ -79,13 +79,15 @@ end
 
 local function toNearestColour(num)
 	-- num between 0 and 360
-	return colours[mathFloor(num - (num % colourStep))] or colours[0] -- fail safe
+	return colours[mathFloor(num)] or colours[0] -- fail safe
+	-- Below could be useful if we want to support custom colour steps (>1)
+	--return colours[mathFloor(num - (num % colourStep))] or colours[0]
 end
 
 -- Draws the 3D2D text with the given positions, angles and data(text/font/col)
 local function Draw3D2D(ang, pos, camangle, data)
 	local multipliedCurtime = CurTime() * 60
-	local speed = 5
+	local colOffset = 5
 
 	for _, row in pairs(data) do
 		cam.Start3D2D(pos, camangle, row[CAMSIZE])
@@ -98,7 +100,7 @@ local function Draw3D2D(ang, pos, camangle, data)
 			if row[RAINBOW] ~= 0 and rainbow_enabled and render_rainbow then
 				for i, char in pairs(row[UTF8CODES]) do
 					--Color
-					surface.SetTextColor(toNearestColour((multipliedCurtime - i * speed) % 360))
+					surface.SetTextColor(toNearestColour((multipliedCurtime - i * colOffset) % 360))
 					--Text
 					surface.DrawText(char)
 				end

--- a/lua/entities/sammyservers_textscreen/init.lua
+++ b/lua/entities/sammyservers_textscreen/init.lua
@@ -60,10 +60,8 @@ function ENT:SetLine(line, text, color, size, font, rainbow)
 	if string.sub(text, 1, 1) == "#" then
 		text = string.sub(text, 2)
 	end
-	if max_characters ~= 0 then
-		if string.len(text) > max_characters then
-			text = string.sub(text, 1, max_characters) .. "..."
-		end
+	if max_characters ~= 0 and string.len(text) > max_characters then
+		text = string.sub(text, 1, max_characters) .. "..."
 	end
 
 	size = math.Clamp(size, 1, 100)

--- a/lua/entities/sammyservers_textscreen/init.lua
+++ b/lua/entities/sammyservers_textscreen/init.lua
@@ -4,6 +4,8 @@ resource.AddFile("materials/textscreens/logo.png")
 
 include("shared.lua")
 
+local max_characters = cvars.Number("ss_max_characters", 0)
+
 
 function ENT:Initialize()
 	self:SetRenderMode(RENDERMODE_TRANSALPHA)
@@ -49,12 +51,15 @@ util.AddNetworkString("textscreens_update")
 util.AddNetworkString("textscreens_download")
 
 function ENT:SetLine(line, text, color, size, font, rainbow)
-	if not text then return end
+	if #text == 0 then return end
+	text = utf8.force(text)
 	if string.sub(text, 1, 1) == "#" then
 		text = string.sub(text, 2)
 	end
-	if string.len(text) > 180 then
-		text = string.sub(text, 1, 180) .. "..."
+	if max_characters ~= 0 then
+		if string.len(text) > max_characters then
+			text = string.sub(text, 1, max_characters) .. "..."
+		end
 	end
 
 	size = math.Clamp(size, 1, 100)
@@ -64,7 +69,7 @@ function ENT:SetLine(line, text, color, size, font, rainbow)
 	rainbow = rainbow or 0
 
 	self.lines = self.lines or {}
-	self.lines[tonumber(line)] = {
+	self.lines[line] = {
 		["text"] = text,
 		["color"] = color,
 		["size"] = size,

--- a/lua/entities/sammyservers_textscreen/init.lua
+++ b/lua/entities/sammyservers_textscreen/init.lua
@@ -50,8 +50,12 @@ hook.Add("PhysgunDrop", "3D2DTextScreensPreventTravelDrop", textScreenDrop)
 util.AddNetworkString("textscreens_update")
 util.AddNetworkString("textscreens_download")
 
+local function isEmptyString(str)
+	return #str == 0 or #string.Replace(str, " ", "") == 0
+end
+
 function ENT:SetLine(line, text, color, size, font, rainbow)
-	if #text == 0 then return end
+	if isEmptyString(text) then return end
 	text = utf8.force(text)
 	if string.sub(text, 1, 1) == "#" then
 		text = string.sub(text, 2)

--- a/lua/weapons/gmod_tool/stools/textscreen.lua
+++ b/lua/weapons/gmod_tool/stools/textscreen.lua
@@ -179,71 +179,83 @@ function TOOL.BuildCPanel(CPanel)
 		changefont:SetText("Change font (" .. font .. ")")
 	end)
 
-	local function SetColor(lineNum, col)
-		RunConsoleCommand("textscreen_r" .. lineNum, col.r)
-		RunConsoleCommand("textscreen_g" .. lineNum, col.g)
-		RunConsoleCommand("textscreen_b" .. lineNum, col.b)
-		RunConsoleCommand("textscreen_a" .. lineNum, col.a)
+	local function SetColor(lineNum, col, uiOnly)
+		if not uiOnly then
+			RunConsoleCommand("textscreen_r" .. lineNum, col.r)
+			RunConsoleCommand("textscreen_g" .. lineNum, col.g)
+			RunConsoleCommand("textscreen_b" .. lineNum, col.b)
+			RunConsoleCommand("textscreen_a" .. lineNum, col.a)
+		end
 	end
 
-	local function ResetColor(lineNum)
-		SetColor(lineNum, Color(255,255,255,255))
+	local function ResetColor(lineNum, uiOnly)
+		SetColor(lineNum, Color(255,255,255,255), uiOnly)
 	end
 
-	local function SetSize(lineNum, size)
+	local function SetSize(lineNum, size, uiOnly)
 		size = tonumber(size) or 20
-		RunConsoleCommand("textscreen_size" .. lineNum, size)
+		if not uiOnly then
+			RunConsoleCommand("textscreen_size" .. lineNum, size)
+		end
 		sliders[lineNum]:SetValue(size)
 		labels[lineNum]:SetFont(textscreenFonts[fontnum] .. "_MENU")
 	end
 
-	local function ResetSize(lineNum)
-		SetSize(lineNum, 20)
+	local function ResetSize(lineNum, uiOnly)
+		SetSize(lineNum, 20, uiOnly)
 	end
 
-	local function SetText(lineNum, text)
-		RunConsoleCommand("textscreen_text" .. lineNum, text)
+	local function SetText(lineNum, text, uiOnly)
+		if not uiOnly then
+			RunConsoleCommand("textscreen_text" .. lineNum, text)
+		end
 		textBox[lineNum]:SetValue(text)
 		labels[lineNum]:SetText(text)
 	end
 
-	local function ResetText(lineNum)
+	local function ResetText(lineNum, uiOnly)
 		SetText(lineNum, "")
 	end
 
-	local function SetFont(lineNum, fontNum)
+	local function SetFont(lineNum, fontNum, uiOnly)
 		fontnum = tonumber(fontNum) or 1
-		RunConsoleCommand("textscreen_font" .. lineNum, fontnum)
+		if not uiOnly then
+			RunConsoleCommand("textscreen_font" .. lineNum, fontnum)
+		end
 		labels[lineNum]:SetFont(textscreenFonts[fontnum] .. "_MENU")
 	end
 
-	local function ResetFont(lineNum)
+	local function ResetFont(lineNum, uiOnly)
 		fontnum = 1
-		SetFont(lineNum, fontnum)
+		SetFont(lineNum, fontnum, uiOnly)
 	end
 
-	local function SetRainbow(lineNum, enabled)
+	local function SetRainbow(lineNum, enabled, uiOnly)
 		enabled = tonumber(tobool(enabled))
-		RunConsoleCommand("textscreen_rainbow" .. lineNum, enabled)
+		if not uiOnly then
+			RunConsoleCommand("textscreen_rainbow" .. lineNum, enabled)
+		end
 		rainbowCheckboxes[lineNum]:SetValue(enabled)
 	end
 
-	local function ResetRainbow(lineNum)
-		SetRainbow(lineNum, 0)
+	local function ResetRainbow(lineNum, uiOnly)
+		SetRainbow(lineNum, 0, uiOnly)
 	end
 
-	local function fnResetLine(lineNum, fns)
+	local function fnResetLine(lineNum, fns, uiOnly)
+		uiOnly = isbool(uiOnly) and uiOnly or false
 		return function()
 			for _, fn in pairs(fns) do
-				fn(lineNum)
+				fn(lineNum, uiOnly)
 			end
 		end
 	end
 
-	local function fnResetAllLines(fns)
+	local function fnResetAllLines(fns, uiOnly)
+		uiOnly = isbool(uiOnly) and uiOnly or false
 		return function()
 			for lineNum = 1, 5 do
-				fnResetLine(lineNum, fns)()
+				fnResetLine(lineNum, fns, uiOnly)()
 			end
 		end
 	end
@@ -256,8 +268,9 @@ function TOOL.BuildCPanel(CPanel)
 		ResetRainbow
 	}
 
-	local function fnResetEverything()
-		fnResetAllLines(allResets)()
+	local function fnResetEverything(uiOnly)
+		uiOnly = isbool(uiOnly) and uiOnly or false
+		fnResetAllLines(allResets, uiOnly)()
 	end
 
 	resetall = vgui.Create("DButton", resetbuttons)
@@ -351,6 +364,7 @@ function TOOL.BuildCPanel(CPanel)
 			rainbow = SetRainbow
 		}
 
+		fnResetEverything(true) -- reset ui
 		for var, val in pairs(data) do
 			local name = getName(var)
 			if fnMap[name] ~= nil then

--- a/lua/weapons/gmod_tool/stools/textscreen.lua
+++ b/lua/weapons/gmod_tool/stools/textscreen.lua
@@ -79,22 +79,19 @@ function TOOL:LeftClick(tr)
 	ply:AddCount("textscreens", textScreen)
 	ply:AddCleanup("textscreens", textScreen)
 
-	for i = 1, 5 do
-		local txt = self:GetClientInfo("text" .. i) or ""
+	for lineNum = 1, 5 do
 		textScreen:SetLine(
-			i, -- Line
-			max_characters ~= 0 and string.Left(txt, max_characters) or txt, -- text
-			Color( -- Color
-				tonumber(self:GetClientInfo("r" .. i)) or 255,
-				tonumber(self:GetClientInfo("g" .. i)) or 255,
-				tonumber(self:GetClientInfo("b" .. i)) or 255,
-				tonumber(self:GetClientInfo("a" .. i)) or 255
+			lineNum,
+			self:GetClientInfo("text" .. lineNum),
+			Color(
+				tonumber(self:GetClientInfo("r" .. lineNum)) or 255,
+				tonumber(self:GetClientInfo("g" .. lineNum)) or 255,
+				tonumber(self:GetClientInfo("b" .. lineNum)) or 255,
+				tonumber(self:GetClientInfo("a" .. lineNum)) or 255
 			),
-			tonumber(self:GetClientInfo("size" .. i)) or 20,
-			-- font
-			tonumber(self:GetClientInfo("font" .. i)) or 1,
-
-			rainbow_enabled == 1 and tonumber(self:GetClientInfo("rainbow" .. i)) or 0
+			tonumber(self:GetClientInfo("size" .. lineNum)),
+			tonumber(self:GetClientInfo("font" .. lineNum)),
+			tonumber(self:GetClientInfo("rainbow" .. lineNum))
 		)
 	end
 
@@ -107,22 +104,19 @@ function TOOL:RightClick(tr)
 	local traceEnt = tr.Entity
 
 	if (IsValid(TraceEnt) and traceEnt:GetClass() == "sammyservers_textscreen") then
-		for i = 1, 5 do
-			local txt = tostring(self:GetClientInfo("text" .. i))
+		for lineNum = 1, 5 do
 			traceEnt:SetLine(
-				i, -- Line
-				max_characters ~= 0 and string.Left(txt, max_characters) or txt, -- text
-				Color( -- Color
-					tonumber(self:GetClientInfo("r" .. i)) or 255,
-					tonumber(self:GetClientInfo("g" .. i)) or 255,
-					tonumber(self:GetClientInfo("b" .. i)) or 255,
-					tonumber(self:GetClientInfo("a" .. i)) or 255
+				lineNum,
+				self:GetClientInfo("text" .. lineNum),
+				Color(
+					tonumber(self:GetClientInfo("r" .. lineNum)) or 255,
+					tonumber(self:GetClientInfo("g" .. lineNum)) or 255,
+					tonumber(self:GetClientInfo("b" .. lineNum)) or 255,
+					tonumber(self:GetClientInfo("a" .. lineNum)) or 255
 				),
-				tonumber(self:GetClientInfo("size" .. i)) or 20,
-				-- font
-				tonumber(self:GetClientInfo("font" .. i)) or 1,
-
-				rainbow_enabled and tonumber(self:GetClientInfo("rainbow" .. i)) or 0
+				tonumber(self:GetClientInfo("size" .. lineNum)),
+				tonumber(self:GetClientInfo("font" .. lineNum)),
+				tonumber(self:GetClientInfo("rainbow" .. lineNum))
 			)
 		end
 
@@ -137,16 +131,16 @@ function TOOL:Reload(tr)
 	local traceEnt = tr.Entity
 	if (not isentity(traceEnt) or traceEnt:GetClass() ~= "sammyservers_textscreen") then return false end
 
-	for i = 1, 5 do
-		local linedata = traceEnt.lines[i]
-		RunConsoleCommand("textscreen_r" .. i, linedata.color.r)
-		RunConsoleCommand("textscreen_g" .. i, linedata.color.g)
-		RunConsoleCommand("textscreen_b" .. i, linedata.color.b)
-		RunConsoleCommand("textscreen_a" .. i, linedata.color.a)
-		RunConsoleCommand("textscreen_size" .. i, linedata.size)
-		RunConsoleCommand("textscreen_text" .. i, linedata.text)
-		RunConsoleCommand("textscreen_font" .. i, linedata.font)
-		RunConsoleCommand("textscreen_rainbow" .. i, linedata.rainbow)
+	for lineNum = 1, 5 do
+		local linedata = traceEnt.lines[lineNum]
+		RunConsoleCommand("textscreen_r" .. lineNum, linedata.color.r)
+		RunConsoleCommand("textscreen_g" .. lineNum, linedata.color.g)
+		RunConsoleCommand("textscreen_b" .. lineNum, linedata.color.b)
+		RunConsoleCommand("textscreen_a" .. lineNum, linedata.color.a)
+		RunConsoleCommand("textscreen_size" .. lineNum, linedata.size)
+		RunConsoleCommand("textscreen_text" .. lineNum, linedata.text)
+		RunConsoleCommand("textscreen_font" .. lineNum, linedata.font)
+		RunConsoleCommand("textscreen_rainbow" .. lineNum, linedata.rainbow)
 	end
 
 	return true
@@ -185,20 +179,85 @@ function TOOL.BuildCPanel(CPanel)
 		changefont:SetText("Change font (" .. font .. ")")
 	end)
 
-	local function ResetFont(lines, text)
-		if #lines >= 5 then
-			fontnum = 1
-			for i = 1, 5 do
-				RunConsoleCommand("textscreen_font" .. i, 1)
+	local function SetColor(lineNum, col)
+		RunConsoleCommand("textscreen_r" .. lineNum, col.r)
+		RunConsoleCommand("textscreen_g" .. lineNum, col.g)
+		RunConsoleCommand("textscreen_b" .. lineNum, col.b)
+		RunConsoleCommand("textscreen_a" .. lineNum, col.a)
+	end
+
+	local function ResetColor(lineNum)
+		SetColor(lineNum, Color(255,255,255,255))
+	end
+
+	local function SetSize(lineNum, size)
+		size = tonumber(size) or 20
+		RunConsoleCommand("textscreen_size" .. lineNum, size)
+		sliders[lineNum]:SetValue(size)
+		labels[lineNum]:SetFont(textscreenFonts[fontnum] .. "_MENU")
+	end
+
+	local function ResetSize(lineNum)
+		SetSize(lineNum, 20)
+	end
+
+	local function SetText(lineNum, text)
+		RunConsoleCommand("textscreen_text" .. lineNum, text)
+		textBox[lineNum]:SetValue(text)
+		labels[lineNum]:SetText(text)
+	end
+
+	local function ResetText(lineNum)
+		SetText(lineNum, "")
+	end
+
+	local function SetFont(lineNum, fontNum)
+		fontnum = tonumber(fontNum) or 1
+		RunConsoleCommand("textscreen_font" .. lineNum, fontnum)
+		labels[lineNum]:SetFont(textscreenFonts[fontnum] .. "_MENU")
+	end
+
+	local function ResetFont(lineNum)
+		fontnum = 1
+		SetFont(lineNum, fontnum)
+	end
+
+	local function SetRainbow(lineNum, enabled)
+		enabled = tonumber(tobool(enabled))
+		RunConsoleCommand("textscreen_rainbow" .. lineNum, enabled)
+		rainbowCheckboxes[lineNum]:SetValue(enabled)
+	end
+
+	local function ResetRainbow(lineNum)
+		SetRainbow(lineNum, 0)
+	end
+
+	local function fnResetLine(lineNum, fns)
+		return function()
+			for _, fn in pairs(fns) do
+				fn(lineNum)
 			end
 		end
-		for k, i in pairs(lines) do
-			if text then
-				RunConsoleCommand("textscreen_text" .. i, "")
-				labels[i]:SetText("")
+	end
+
+	local function fnResetAllLines(fns)
+		return function()
+			for lineNum = 1, 5 do
+				fnResetLine(lineNum, fns)()
 			end
-			labels[i]:SetFont(textscreenFonts[fontnum] .. "_MENU")
 		end
+	end
+
+	local allResets = {
+		ResetColor,
+		ResetSize,
+		ResetText,
+		ResetFont,
+		ResetRainbow
+	}
+
+	local function fnResetEverything()
+		fnResetAllLines(allResets)()
 	end
 
 	resetall = vgui.Create("DButton", resetbuttons)
@@ -208,59 +267,16 @@ function TOOL.BuildCPanel(CPanel)
 	resetall.DoClick = function()
 		local menu = DermaMenu()
 
-		menu:AddOption("Reset colors", function()
-			for i = 1, 5 do
-				RunConsoleCommand("textscreen_r" .. i, 255)
-				RunConsoleCommand("textscreen_g" .. i, 255)
-				RunConsoleCommand("textscreen_b" .. i, 255)
-				RunConsoleCommand("textscreen_a" .. i, 255)
-			end
-		end)
-
-		menu:AddOption("Reset sizes", function()
-			for i = 1, 5 do
-				RunConsoleCommand("textscreen_size" .. i, 20)
-				sliders[i]:SetValue(20)
-				labels[i]:SetFont(textscreenFonts[fontnum] .. "_MENU")
-			end
-		end)
-
-		menu:AddOption("Reset textboxes", function()
-			for i = 1, 5 do
-				RunConsoleCommand("textscreen_text" .. i, "")
-				textBox[i]:SetValue("")
-			end
-		end)
-
-		menu:AddOption("Reset fonts", function()
-			ResetFont({1, 2, 3, 4, 5}, false)
-		end)
+		menu:AddOption("Reset colors", fnResetAllLines({ResetColor}))
+		menu:AddOption("Reset sizes", fnResetAllLines({ResetSize}))
+		menu:AddOption("Reset textboxes", fnResetAllLines({ResetText}))
+		menu:AddOption("Reset fonts", fnResetAllLines({ResetFont}))
 
 		if rainbow_enabled == 1 then
-			menu:AddOption("Reset rainbow", function()
-				for i = 1, 5 do
-					rainbowCheckboxes[i]:SetValue(0)
-				end
-			end)
+			menu:AddOption("Reset rainbow", fnResetAllLines({ResetRainbow}))
 		end
 
-		menu:AddOption("Reset everything", function()
-			for i = 1, 5 do
-				RunConsoleCommand("textscreen_r" .. i, 255)
-				RunConsoleCommand("textscreen_g" .. i, 255)
-				RunConsoleCommand("textscreen_b" .. i, 255)
-				RunConsoleCommand("textscreen_a" .. i, 255)
-				RunConsoleCommand("textscreen_size" .. i, 20)
-				sliders[i]:SetValue(20)
-				RunConsoleCommand("textscreen_text" .. i, "")
-				RunConsoleCommand("textscreen_font" .. i, 1)
-				textBox[i]:SetValue("")
-				if rainbow_enabled == 1 then
-					rainbowCheckboxes[i]:SetValue(0)
-				end
-			end
-			ResetFont({1, 2, 3, 4, 5}, true)
-		end)
+		menu:AddOption("Reset everything", fnResetEverything)
 
 		menu:Open()
 	end
@@ -274,33 +290,8 @@ function TOOL.BuildCPanel(CPanel)
 		local menu = DermaMenu()
 
 		for i = 1, 5 do
-			menu:AddOption("Reset line " .. i, function()
-				RunConsoleCommand("textscreen_r" .. i, 255)
-				RunConsoleCommand("textscreen_g" .. i, 255)
-				RunConsoleCommand("textscreen_b" .. i, 255)
-				RunConsoleCommand("textscreen_a" .. i, 255)
-				RunConsoleCommand("textscreen_size" .. i, 20)
-				sliders[i]:SetValue(20)
-				RunConsoleCommand("textscreen_text" .. i, "")
-				textBox[i]:SetValue("")
-				ResetFont({i}, true)
-			end)
+			menu:AddOption("Reset line " .. i, fnResetLine(i, allResets))
 		end
-
-		menu:AddOption("Reset all lines", function()
-			for i = 1, 5 do
-				RunConsoleCommand("textscreen_r" .. i, 255)
-				RunConsoleCommand("textscreen_g" .. i, 255)
-				RunConsoleCommand("textscreen_b" .. i, 255)
-				RunConsoleCommand("textscreen_a" .. i, 255)
-				RunConsoleCommand("textscreen_size" .. i, 20)
-				sliders[i]:SetValue(20)
-				RunConsoleCommand("textscreen_text" .. i, "")
-				RunConsoleCommand("textscreen_font" .. i, 1)
-				textBox[i]:SetValue("")
-			end
-			ResetFont({1, 2, 3, 4, 5}, true)
-		end)
 
 		menu:Open()
 	end
@@ -332,7 +323,7 @@ function TOOL.BuildCPanel(CPanel)
 
 	CPanel:AddItem(changefont)
 
-	CPanel:AddControl("ComboBox", {
+	local controlPresets = CPanel:AddControl("ComboBox", {
 		MenuButton = 1,
 		Folder = "textscreen",
 		Options = {
@@ -340,6 +331,36 @@ function TOOL.BuildCPanel(CPanel)
 		},
 		CVars = table.GetKeys(conVarsDefault)
 	})
+	local originalOnSelect = controlPresets.DropDown.OnSelect
+	controlPresets.DropDown.OnSelect = function(self, index, value, data, ...)
+		local ret = originalOnSelect(self, index, value, data, ...)
+
+		local prefix = "textscreen"
+		local getName = function(var) 
+			return string.match(var, prefix .. "_(%a+)") 
+		end
+		local getLine = function(var) 
+			return tonumber(string.match(var, prefix .. "_%a+(%d)")) 
+		end
+
+		-- Go over all those that directly set UI elements
+		local fnMap = {
+			size = SetSize,
+			text = SetText,
+			font = SetFont,
+			rainbow = SetRainbow
+		}
+
+		for var, val in pairs(data) do
+			local name = getName(var)
+			print(var, name, getLine(var), val)
+			if fnMap[name] ~= nil then
+				fnMap[name](getLine(var), val)
+			end
+		end
+
+		return ret
+	end
 
 	for i = 1, 5 do
 		lineLabels[i] = CPanel:AddControl("Label", {

--- a/lua/weapons/gmod_tool/stools/textscreen.lua
+++ b/lua/weapons/gmod_tool/stools/textscreen.lua
@@ -353,7 +353,6 @@ function TOOL.BuildCPanel(CPanel)
 
 		for var, val in pairs(data) do
 			local name = getName(var)
-			print(var, name, getLine(var), val)
 			if fnMap[name] ~= nil then
 				fnMap[name](getLine(var), val)
 			end

--- a/lua/weapons/gmod_tool/stools/textscreen.lua
+++ b/lua/weapons/gmod_tool/stools/textscreen.lua
@@ -144,7 +144,7 @@ function TOOL:Reload(tr)
 			RunConsoleCommand("textscreen_rainbow" .. lineNum, 0)
 		end
 	end
-	
+
 	for lineNum, linedata in pairs(traceEnt.lines) do
 		RunConsoleCommand("textscreen_r" .. lineNum, linedata.color.r)
 		RunConsoleCommand("textscreen_g" .. lineNum, linedata.color.g)
@@ -289,7 +289,7 @@ function TOOL.BuildCPanel(CPanel)
 	-- Update ui when copying screens
 	local function addConVarListener(var, setter)
 		for i = 1, 5 do
-			cvars.AddChangeCallback(var..i, function(convar_name, value_old, value_new)
+			cvars.AddChangeCallback(var .. i, function(convar_name, value_old, value_new)
 				setter(i, value_new, true)
 			end)
 		end
@@ -301,7 +301,7 @@ function TOOL.BuildCPanel(CPanel)
 		rainbow = SetRainbow
 	}
 	for name, fn in pairs(fnMap) do
-		addConVarListener(prefix.."_"..name, fn)
+		addConVarListener(prefix .. "_" .. name, fn)
 	end
 
 	resetall = vgui.Create("DButton", resetbuttons)


### PR DESCRIPTION
Hi, rainbow text is pretty performance intensive, so I had a look to see what I could do.

In some testing, I found that my changes have reduced the average runtime from 0.179ms to 0.047ms for a 10 second FProfile, looking at a screen with two lines of rainbow text saying _Test this textscreen_ (size 50).

When I placed roughly 20 on the map and compared it to the existing drawing code, my FPS went from 100 to 140.

The biggest performance improvement came from removing utf8.codes and utf8.char. Caching colours only made a 0.02ms average call time difference in testing.

Hopefully this will allow more players to keep rainbow text enabled, as it is pretty cool.

One important note is that I've changed the animation direction, from right to left, to left to right. This is my preferred style choice, but I can set it back.

Fixes #88 