### PR TITLE
Fix AdvDupe2 support, allow all tools (except ones causing #60) to be used on textscreens

### DIFF
--- a/lua/entities/sammyservers_textscreen/init.lua
+++ b/lua/entities/sammyservers_textscreen/init.lua
@@ -132,3 +132,12 @@ end
 function ENT:Broadcast()
 	self:SendLines(nil)
 end
+
+function ENT:Think()
+	if not self:IsSolid() then -- Removes textscreen if it can not be picked by toolgun (and removed by admins)
+		self:Remove()
+	end
+
+	self:NextThink(CurTime() + 5)
+	return true
+end

--- a/lua/entities/sammyservers_textscreen/init.lua
+++ b/lua/entities/sammyservers_textscreen/init.lua
@@ -141,3 +141,5 @@ function ENT:Think()
 	self:NextThink(CurTime() + 5)
 	return true
 end
+
+duplicator.RegisterEntityClass("sammyservers_textscreen", duplicator.GenericDuplicatorFunction, "Data")

--- a/lua/entities/sammyservers_textscreen/shared.lua
+++ b/lua/entities/sammyservers_textscreen/shared.lua
@@ -10,10 +10,4 @@ function ENT:SetupDataTables()
 	self:NetworkVar("Bool", 0, "IsPersisted")
 end
 
-local function textScreenCanTool(ply, trace, tool)
-	-- only allow textscreen, remover, and permaprops tool
-	if IsValid(trace.Entity) and trace.Entity:GetClass() == "sammyservers_textscreen" and tool ~= "textscreen" and tool ~= "remover" and tool ~= "permaprops" then
-		return false
-	end
-end
 hook.Add("CanTool", "3D2DTextScreensPreventTools", textScreenCanTool)


### PR DESCRIPTION
It is already possible to area-copy textscreen and paste it, but that previous broke it.

I tried detouring ENT:SetNotSolid on textscreens, because it is the cause of #60, but it not worked, so I check for `ENT:IsSolid() == false` each 5 seconds.