### PR TITLE
Change resource.AddFile -> resource.AddWorkshop

### DIFF
--- a/lua/entities/sammyservers_textscreen/init.lua
+++ b/lua/entities/sammyservers_textscreen/init.lua
@@ -1,6 +1,6 @@
 AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
-resource.AddFile("materials/textscreens/logo.png")
+resource.AddWorkshop("109643223")
 
 include("shared.lua")
 


### PR DESCRIPTION
This PR changes the `resource.AddFile` function to `resource.AddWorkshop`. Currently the `.property` files aren't downloaded for clients, and servers not using FastDL don't have clients download the logo file when using the `resource.AddFile` method, so `resource.AddWorkshop` allows for clients to get both the logo & `.property` files. 